### PR TITLE
Change ErrorAction from SilentlyContinue to Ignore

### DIFF
--- a/DockerCompletion/NativeCommandCompletion/NativeCommandCompletion.psm1
+++ b/DockerCompletion/NativeCommandCompletion/NativeCommandCompletion.psm1
@@ -114,7 +114,7 @@ function Register-NativeCommandArgumentCompleter {
 		[scriptblock]$ScriptBlock
 	)
 
-	$CommandName, (Get-Alias -Definition $CommandName -ErrorAction SilentlyContinue).Name | ForEach-Object {
+	$CommandName, (Get-Alias -Definition $CommandName -ErrorAction Ignore).Name | ForEach-Object {
 		if ($_) {
 			Register-ArgumentCompleter -CommandName $_ -ScriptBlock $ScriptBlock -Native
 		}


### PR DESCRIPTION
If you use `SilentlyContinue` the error gets added to `$global:error`, which is not what you would expect, as you don't intend to inpect the error later, and causes side effects. Simply ignore the error.

I found this when I added this module and started seeing errors on PowerShell startup, which should be clean.